### PR TITLE
Fixed syntax error on LicenseServerIP reference

### DIFF
--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -332,7 +332,7 @@ Resources:
         InstanceCount: !Ref InstanceCount
         PublicRemoteCidr: !Ref PublicRemoteCidr
         PrimaryNodeIP: !Ref PrimaryNodeIP
-        LicenseServerIP: !LicenseServerIP
+        LicenseServerIP: !Ref LicenseServerIP
         MediaS3Bucket: !Ref MediaS3Bucket
         MediaS3Key: !Ref MediaS3Key
         SceneAddress: !Ref SceneAddress


### PR DESCRIPTION
The template reports an error which seems to be an incorrect reference to the LicenseServerIP.  I've made a change which Cloudformation approves.
