### PR TITLE
Fix issues when starting VRED

### DIFF
--- a/scripts/run-vred.ps1
+++ b/scripts/run-vred.ps1
@@ -6,9 +6,9 @@
 .COPYRIGHT Autodesk, Inc. All Rights Reserved.
 #>
 
-<# 
-.DESCRIPTION 
- A script to start VRED Core on an AWS EC2 Windows instance. 
+<#
+.DESCRIPTION
+ A script to start VRED Core on an AWS EC2 Windows instance.
  It handles the following tasks:
  * Set the license server Autodesk VRED
  * Download a VRED scene file to a temporary directory or
@@ -16,7 +16,7 @@
  * Start VRED Core with scene file
  * Run python script to switch display mode as soon a HMD is available
  * Run python script to connect VRED to a collaboration session
-#> 
+#>
 Param (
   [parameter(Mandatory=$true, HelpMessage="The address of the ADSK license server.")]
   [String]
@@ -56,14 +56,11 @@ Set-AdskLicense $LicenseServer
 # Create temp folder
 $tempPath = New-TempFolder
 
-# Extract filename from scene address
-$sceneFilename = Split-Path -Path $Scene -Leaf
-
 # Path to scene file in temp folder
-$scenePath = Join-Path $tempPath $sceneFilename
+$scenePath = Join-Path $tempPath $Scene
 
 # Copy scene file from AWS S3 bucket or web server to temporary directory
-if (![string]::IsNullOrWhiteSpace($S3Bucket)) {  
+if (![string]::IsNullOrWhiteSpace($S3Bucket)) {
   Write-Output "Copy scene file from AWS S3 bucket '$S3Bucket' to local temp folder"
 
   if (![string]::IsNullOrWhiteSpace($AccessKey) -or ![string]::IsNullOrWhiteSpace($SecretKey)) {
@@ -73,9 +70,14 @@ if (![string]::IsNullOrWhiteSpace($S3Bucket)) {
   }
 } elseif (Test-UriScheme($Scene, @("http", "https"))) {
   Write-Output "Download scene file from '$Scene' to local temp folder"
-  
+
   # Improve download performance by disabling the display of progress
   $ProgressPreference = 'SilentlyContinue'
+
+  # Extract filename from scene address and update path
+  $sceneFilename = Split-Path -Path $Scene -Leaf
+  $scenePath = Join-Path $tempPath $sceneFilename
+
   Invoke-WebRequest $Scene -OutFile $scenePath
 }
 

--- a/scripts/vred-library.psm1
+++ b/scripts/vred-library.psm1
@@ -48,7 +48,7 @@ function Join-VredCollaboration {
   )
 
   Write-Output "VRED Core join collaboration session $Address"
-  
+
   try {
     # A script to change the display mode to open vr as soon as an Hmd is active
     $script = 'vrSessionService.join("' + $Address + '", userName="' + $UserName + '", color=PySide2.QtGui.Qt.transparent, roomName="AWS", passwd="", forceVersion=False)'
@@ -79,10 +79,10 @@ function Set-AdskLicense {
     $LicenseServer
   )
 
-  Write-Output "Change license server to $LicenseServer" 
-  
+  Write-Output "Change license server to $LicenseServer"
+
   try {
-    Start-Process -FilePath "C:\Program Files (x86)\Common Files\Autodesk Shared\AdskLicensing\Current\helper\AdskLicensingInstHelper.exe" -ArgumentList "change --pk 887N1 --pv 2022.0.0.F -lm NETWORK -ls $LicenseServer"
+    Start-Process -FilePath "C:\Program Files (x86)\Common Files\Autodesk Shared\AdskLicensing\Current\helper\AdskLicensingInstHelper.exe" -ArgumentList "change --pk 887O1 --pv 2023.0.0.F -lm NETWORK -ls $LicenseServer" -Wait
   } catch [InvalidOperationException] {
     Write-Output "Change license server failed"
     Write-Host -ForegroundColor Red $_


### PR DESCRIPTION
The scene path was wrong if the scene was in a subfolder on an S3 bucket.
The product key for VRED Core 2023 has changed, so the license server could not be set for this version.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
