### PR TITLE
Fix old install scripts calls, NICE DCV license, descriptions, typos, consistency and outputs

### DIFF
--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -299,3 +299,21 @@ Resources:
         MediaS3Key: !Ref MediaS3Key
         SceneAddress: !Ref SceneAddress
         VredInstanceTag: !Ref VredInstanceTag
+
+Outputs:
+  VredInstanceID:
+    Description: EC2 Instance ID
+    Value: !GetAtt WorkloadStack.Outputs.VredInstanceID
+  VredSecurityGroup:
+    Description: Security Group For VRED Instances
+    Value: !GetAtt WorkloadStack.Outputs.VredSecurityGroup
+  VredPrimaryNodeURL:
+    Description: Url to Access VRED Primary Node(login as administrator)
+    Value: !GetAtt WorkloadStack.Outputs.VredPrimaryNodeURL
+  VredAutoScalingGroup:
+    Description: Auto Scaling Group Details
+    Value: !GetAtt WorkloadStack.Outputs.VredAutoScalingGroup
+  NiceDCVdownload:
+    Description: NICE DCV client download url
+    Value: !GetAtt WorkloadStack.Outputs.NiceDCVdownload
+

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -1,7 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description:
-  This template deploys an EC2 instnace using the Nvidia Windows Marketplace AMI in an New VPC (qs-1t26ph9hg)
-  
+  Deploys Autodesk VRED 3D and Nvidia CloudXR on the AWS Cloud into a new VPC.
+  This option builds a new AWS environment that consists of the VPC, subnets, security groups, and other infrastructure components. 
+  It then deploys VRED into this new VPC. (qs-1t26ph9hg)
+
 Metadata:
   cfn-lint:
     config:
@@ -28,7 +30,7 @@ Metadata:
       - PublicSubnet3CIDR
       - PublicRemoteCidr
     - Label:
-        default: VRED Amazon EC2 configuration
+        default: VRED Amazon EC2 Instance configuration
       Parameters:
       - WorkloadInstanceType
 #      - CloudxrAMI
@@ -39,7 +41,7 @@ Metadata:
       - LicenseServerIP
       - VredInstanceTag
     - Label:
-        default: VRED media configuration
+        default: Autodesk VRED 3D Media configuration
       Parameters:
       - MediaS3Bucket
       - MediaS3Key
@@ -56,11 +58,11 @@ Metadata:
       VPCCIDR:
         default: VPC CIDR
       PublicSubnet1CIDR:
-        default: Public subnet 1 CIDR
+        default: Public Subnet A CIDR
       PublicSubnet2CIDR:
-        default: Public subnet 2 CIDR
+        default: Public Subnet B CIDR
       PublicSubnet3CIDR:
-        default: Public subnet 3 CIDR
+        default: Public Subnet C CIDR
       QSS3BucketName:
         default: Quick Start S3 bucket name
       QSS3BucketRegion:
@@ -68,9 +70,9 @@ Metadata:
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
       WorkloadInstanceType:
-        default: Workload servers instance type
+        default: Workload servers EC2 Instance type
       VredInstanceTag:
-        default: Tag value for VRED Instance
+        default: EC2 Instance Tag (Environment)
 #      CloudxrAMI:
 #        default: Workload servers Cloudxr version
       CloudxrStorageVolumeSize:
@@ -86,11 +88,11 @@ Metadata:
       LicenseServerIP:
         default: Network License Manager IP Address
       MediaS3Bucket:
-        default: VRED media S3 bucekt
+        default: Autodesk VRED 3D Media Bucket
       MediaS3Key:
-        default: VRED media S3 key
+        default: Autodesk VRED 3D Media Key Prefix
       SceneAddress:
-        default: The address to a VRED scene file
+        default: Scene file
 
 Parameters:
 
@@ -178,7 +180,7 @@ Parameters:
     - g5.16xlarge
     ConstraintDescription: Must contain valid instance type.
     Default: g4dn.2xlarge
-    Description: Type of EC2 instance for the workload instances.
+    Description: The Amazon EC2 instance type for the Autodesk VRED instances.
     Type: String
 #  CloudxrAMI:
 #    Type: String
@@ -190,16 +192,16 @@ Parameters:
   VredInstanceTag:
     Type: String
     Default: VRED
-    Description: Environment tag value for VRED  instances
+    Description: Environment tag value for VRED instances
   CloudxrStorageVolumeSize:
     Type: Number
     Default: 200
     ConstraintDescription: Must be between 200 GB and 16,000 GB (16 TB).
     MinValue: 1
     MaxValue: 16000
-    Description: Size of Cloudxr virtualized storage in GBs. 
+    Description: Size of CloudXR virtualized storage in GBs.
   InstanceCount:
-    Description: Number of EC2 instances for collabration (Excludes Primary Node)
+    Description: Number of EC2 instances for collaboration (Excludes Primary Node)
     Type: Number
     Default: 1
     MinValue: 1
@@ -209,34 +211,36 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
     Default: 10.0.0.0/16
-    Description: The CIDR IP range that is  permitted to access the bastion hosts and Autodesk VRED. We recommend that  you set this value to a trusted IP range. For example, you might want to  grant only your corporate network access to the software. The CIDR block must  be in the form x.x.x.x/x.
+    Description: The CIDR IP range that is permitted to access the bastion hosts and Autodesk VRED. We recommend that you set this value to a trusted IP range. For example, you might want to grant only your corporate network access to the software. The CIDR block must be in the form x.x.x.x/x.
     Type: String
   PrimaryNodeIP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
     Default: 10.0.128.100
-    Description: IP for primary node of VRED  Cluster. Primary private IP for the first cluster node located in  Availability Zone 1 - Prefer PublicsubnetAID.
+    Description: IP for primary node of VRED Cluster. Primary private IP for the first cluster node located in Public Subnet A - Availability Zone 1.
     Type: String
   LicenseServerIP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
     Default: 10.0.128.109
-    Description: IP for VRED NLM server.  Ensure public subnet is able to connect to  NLM server subnet. Refer to NLM instructions for more information
+    Description: IP for VRED NLM server. Ensure public subnet is able to connect to NLM server subnet. Refer to NLM instructions for more information.
     Type: String
   MediaS3Bucket:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: The bucket name can include numbers, lowercase
       letters, uppercase letters, and hyphens (-). It cannot start or end with a 
       hyphen (-).
-    Description: The S3 bucket you have created to store VRED and SteamXR installation media.
+    Description: The S3 bucket you have created to store Autodesk VRED and SteamVR installation media.
     Type: String
   MediaS3Key:
     ConstraintDescription: The Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
-    Description: The S3 key name prefix for installation media. Store VRED installation media, STEAMXR binaries in format (SteamVR.zip)and Scene file  under this key prefix. Kindly follow pre-requisites for more details.
+    Description: S3 key prefix that is used to simulate a folder for your copy of the installation media. Autodesk VRED 3D (*.sfx.exe), SteamVR installation binaries (SteamVR.zip) and your scene file under this key prefix. Kindly follow pre-requisites for more details in the documentation. End with a forward slash.
     Type: String
+    Default: replace-me-quickstart-nvidia-cloudxr-media/
   SceneAddress:
-    Description: The address to a VRED scene file. Address should be in format {MediaS3Key}/{Name OF Scene File}
+    Description: Autodesk VRED 3D Scene file. Address should be in format (MediaS3Key/Scene.pdb)
     Type: String
-      
+    Default: replace-me-quickstart-nvidia-cloudxr-media/my_scene.pdb
+
 #Mappings:
 #  AMI:
 #    Alias:

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description:
-  This template deploys an EC2 instnace using the Nvidia Windows Marketplace AMI in an existing VPC (qs-1t26ph9er)
+  Deploys Autodesk VRED 3D and Nvidia CloudXR on the AWS Cloud into an existing VPC.
+  This option provisions VRED in your existing AWS infrastructure. (qs-1t26ph9er)
 
 Metadata:
   cfn-lint:
@@ -15,6 +16,7 @@ Metadata:
         owner-alias: aws-marketplace
         product-code.type: marketplace
         product-code: bwhppj014bz7uf8lehfv4u8hs
+
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
@@ -27,7 +29,7 @@ Metadata:
 
       # See lab instructions
     - Label:
-        default: Amazon EC2 configuration
+        default: VRED Amazon EC2 Instance configuration
       Parameters:
       - WorkloadInstanceType
 #      - CloudxrAMI
@@ -39,7 +41,7 @@ Metadata:
       - LicenseServerIP
       - VredInstanceTag
     - Label:
-        default: VRED media configuration
+        default: Autodesk VRED 3D Media configuration
       Parameters:
       - MediaS3Bucket
       - MediaS3Key
@@ -54,11 +56,11 @@ Metadata:
       VPCID:
         default: VPC ID
       PublicSubnetAID:
-        default: Public subnet A ID
+        default: Public Subnet A Id
       PublicSubnetBID:
-        default: Public subnet B ID
+        default: Public Subnet B Id
       PublicSubnetCID:
-        default: Public subnet C ID
+        default: Public Subnet C Id
       QSS3BucketName:
         default: Quick Start S3 bucket name
       QSS3BucketRegion:
@@ -66,9 +68,9 @@ Metadata:
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
       WorkloadInstanceType:
-        default: Workload servers instance type
+        default: Workload servers EC2 Instance type
       VredInstanceTag:
-        default: Tag value for VRED Instance
+        default: EC2 Instance Tag (Environment)
 #      CloudxrAMI:
 #        default: Workload servers Cloudxr version
       CloudxrStorageVolumeSize:
@@ -84,11 +86,12 @@ Metadata:
       LicenseServerIP:
         default: Network License Manager IP Address
       MediaS3Bucket:
-        default: VRED media S3 bucekt
+        default: Autodesk VRED 3D Media Bucket
       MediaS3Key:
-        default: VRED media S3 key
+        default: Autodesk VRED 3D Media Key Prefix
       SceneAddress:
-        default: The address to a VRED scene file
+        default: Scene file
+
 Parameters:
   VPCID:
     Description: ID of your existing VPC for deployment(VPC must have internet connectivity)
@@ -156,7 +159,7 @@ Parameters:
     - g5.16xlarge
     ConstraintDescription: Must contain valid instance type.
     Default: g4dn.2xlarge
-    Description: The Amazon EC2 instance type for  the Autodesk VRED instances.
+    Description: The Amazon EC2 instance type for the Autodesk VRED instances.
     Type: String
 #  CloudxrAMI:
 #    Type: String
@@ -170,13 +173,13 @@ Parameters:
     ConstraintDescription: Must be between 200 GB and 16,000 GB (16 TB).
     MinValue: 1
     MaxValue: 16000
-    Description: Size of Cloudxr virtualized storage in GBs.
+    Description: Size of CloudXR virtualized storage in GBs.
   VredInstanceTag:
     Type: String
     Default: VRED
-    Description: Environment tag value for VRED  instances
+    Description: Environment tag value for VRED instances
   InstanceCount:
-    Description: Number of EC2 instances for collabration (Excludes Primary Node).
+    Description: Number of EC2 instances for collaboration (Excludes Primary Node).
     Type: Number
     Default: 1
     MinValue: 1
@@ -186,32 +189,34 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
     Default: 0.0.0.0/0
-    Description: The CIDR IP range that is  permitted to access the bastion hosts and Autodesk VRED. We recommend that  you set this value to a trusted IP range. For example, you might want to  grant only your corporate network access to the software. The CIDR block must  be in the form x.x.x.x/x.
+    Description: The CIDR IP range that is permitted to access the bastion hosts and Autodesk VRED. We recommend that you set this value to a trusted IP range. For example, you might want to grant only your corporate network access to the software. The CIDR block must be in the form x.x.x.x/x.
     Type: String
   PrimaryNodeIP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
     Default: 11.0.0.69
-    Description: IP for primary node of VRED  Cluster. Primary private IP for the first cluster node located in  Availability Zone 1 - Prefer PublicsubnetAID.
+    Description: IP for primary node of VRED Cluster. Primary private IP for the first cluster node located in Public Subnet A - Availability Zone 1.
     Type: String
   LicenseServerIP:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
-    Description: IP for VRED NLM server.  Ensure public subnet is able to connect to  NLM server subnet. Refer to NLM instructions for more information
+    Description: IP for VRED NLM server. Ensure public subnet is able to connect to NLM server subnet. Refer to NLM instructions for more information.
     Type: String
   MediaS3Bucket:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: The bucket name can include numbers, lowercase
       letters, uppercase letters, and hyphens (-). It cannot start or end with a
       hyphen (-).
-    Description: The S3 bucket you have created to store VRED and SteamXR installation media.
+    Description: The S3 bucket you have created to store Autodesk VRED and SteamVR installation media.
     Type: String
   MediaS3Key:
     ConstraintDescription: The Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
-    Description: The S3 key name prefix for installation media. Store VRED installation media, STEAMXR binaries in format (SteamVR.zip)and Scene file  under this key prefix. Kindly follow pre-requisites for more details.
+    Description: S3 key prefix that is used to simulate a folder for your copy of the installation media. Autodesk VRED 3D (*.sfx.exe), SteamVR installation binaries (SteamVR.zip) and your scene file under this key prefix. Kindly follow pre-requisites for more details in the documentation. End with a forward slash.
     Type: String
+    Default: replace-me-quickstart-nvidia-cloudxr-media/
   SceneAddress:
-    Description: The address to a VRED scene file. Address should be in format {MediaS3Key}/{Name OF Scene File}
+    Description: Autodesk VRED 3D Scene file. Address should be in format (MediaS3Key/Scene.pdb)
     Type: String
+    Default: replace-me-quickstart-nvidia-cloudxr-media/my_scene.pdb
 
 Mappings:
   AWSAMIRegionMap:
@@ -590,8 +595,5 @@ Outputs:
     Description: Auto Scaling Group Details
     Value: !Ref WindowsNvidiaWorkstation
   DCVdownload:
-    Description: DCV client download
+    Description: Nice DCV client download url
     Value: https://download.nice-dcv.com/latest.html
-
-
-

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -594,6 +594,6 @@ Outputs:
   VredAutoScalingGroup:
     Description: Auto Scaling Group Details
     Value: !Ref WindowsNvidiaWorkstation
-  DCVdownload:
+  NiceDCVdownload:
     Description: Nice DCV client download url
     Value: https://download.nice-dcv.com/latest.html

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -353,6 +353,15 @@ Resources:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
                 Resource: "*"
+        - PolicyName: NiceDCVLicense
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::dcv-license.${AWS::Region}/*"
+
   WorkstationAccessProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -408,12 +408,6 @@ Resources:
                 - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/install-vred.ps1
                 - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
                   S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
-            C:\cfn\scripts\installvred.ps1:
-              source:
-                !Sub
-                - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/installvred.ps1
-                - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
-                  S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
             C:\cfn\scripts\run-vred.ps1:
               source:
                 !Sub
@@ -513,12 +507,6 @@ Resources:
               source:
                 !Sub
                 - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/install-vred.ps1
-                - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
-                  S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
-            C:\cfn\scripts\installvred.ps1:
-              source:
-                !Sub
-                - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/installvred.ps1
                 - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
                   S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
             C:\cfn\scripts\run-vred.ps1:


### PR DESCRIPTION
Works OK after removing the copy/execution of the old scripts not present at Quickstart
