### PR TITLE
CloudXR 3.2, DirectX Runtime, g5.2xlarge, typo

### DIFF
--- a/scripts/install-vred.ps1
+++ b/scripts/install-vred.ps1
@@ -81,6 +81,18 @@ if (![string]::IsNullOrWhiteSpace($AccessKey) -or ![string]::IsNullOrWhiteSpace(
   Copy-S3Object -BucketName $S3Bucket -KeyPrefix $InstallerPrefix -LocalFolder $tempPath
 }
 
+####################################################################################################
+# Install DirectX End-User Runtime Web Installer
+#
+# DirectX End-User Runtime Web Installer [dxwebsetup.exe] must be added to the S3 bucket folder of media and binaries.
+#
+# It can be downloaded from:
+# https://www.microsoft.com/en-us/download/details.aspx?id=35
+####################################################################################################
+
+# Extract DirectX files
+$DxExe = Join-Path $tempPath "dxwebsetup.exe"
+Start-Process -FilePath $DxExe -ArgumentList "/Q" -Wait
 
 ####################################################################################################
 # Install VRED Core and set the license server

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -272,7 +272,6 @@ Resources:
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         WorkloadInstanceType: !Ref WorkloadInstanceType
-#        CloudxrAMI: !Ref CloudxrAMI
         CloudxrStorageVolumeSize: !Ref CloudxrStorageVolumeSize
         KeyPairName: !Ref KeyPairName
         InstanceCount: !Ref InstanceCount

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -65,7 +65,7 @@ Metadata:
       QSS3BucketName:
         default: Partner Solution S3 bucket name
       QSS3BucketRegion:
-        default: Parnter Solution S3 bucket Region
+        default: Partner Solution S3 bucket Region
       QSS3KeyPrefix:
         default: Partner Solution S3 key prefix
       WorkloadInstanceType:

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -175,7 +175,7 @@ Parameters:
     - g5.12xlarge
     - g5.16xlarge
     ConstraintDescription: Must contain valid instance type.
-    Default: g4dn.2xlarge
+    Default: g5.2xlarge
     Description: Amazon EC2 instance type for Autodesk VRED instances.
     Type: String
   VredInstanceTag:

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -217,8 +217,7 @@ Parameters:
   ImageId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Description: CloudXR is NVIDIA's streaming SDK.
-    Default: /aws/service/marketplace/prod-7msqr5zacq4i6/cloudxr-3.1-vgpu-13.1
-#    Default: /aws/service/marketplace/prod-7msqr5zacq4i6/cloudxr-3.2-vgpu-14.1
+    Default: /aws/service/marketplace/prod-7msqr5zacq4i6/cloudxr-3.2-vgpu-14.1
 
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']


### PR DESCRIPTION
This Pull Request includes several changes to the repository:

* The AWSCli has been deleted from the repository (commit ff936260)
* A typo has been fixed (commit 3dc2ed84)
* The default AMI has been set to CloudXR 3.2 (cloudxr-3.2-vgpu-14.1) (commit 62316b99)
* An unused parameter for the CloudXR AMI has been removed (commit 8336e507)
* The default EC2 Instance has been updated to g5.2xlarge (commit cbec34e5)
* The DirectX End-User Runtime Web Installer (dxwebsetup.exe) has been installed to avoid the "dx10.dll not found CXR3.2" error (commit 957deeb2)

It is recommended to take a look at the CloudXRAdmin user as it is not clear which user is being logged into the Instance. 

Additionally, the DirectX End-User Runtime Web Installer must be added to the S3 bucket folder of media and binaries. It can be downloaded from the Microsoft website: https://www.microsoft.com/en-us/download/details.aspx?id=35.
